### PR TITLE
Changed the hugging face repository, elastic/multilingual-e5-small only hosts README file

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
@@ -275,7 +275,7 @@ your system.
 --
 [source,bash]
 ----
-git clone https://huggingface.co/elastic/multilingual-e5-small
+git clone https://huggingface.co/intfloat/multilingual-e5-small
 ----
 The command results in a local copy of the model in the `multilingual-e5-small`
 directory.


### PR DESCRIPTION
Changed the hugging face repository as the elastic/multilingual-e5-small hugging face repository only hosts a README file. Subsequent steps to deploy the model fail as the cloned repository don't contain any model files.